### PR TITLE
pymysql.org link updated in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ What's CyMySQL
 
 This package contains a python MySQL client library.
 
-It is a fork project from PyMySQL https://pymysql.readthedocs.io.
+It is a fork project from PyMySQL https://pymysql.readthedocs.io/en/latest/.
 
 PyMySQL is written by Yutaka Matsubara <yutaka.matsubara@gmail.com>
 as a pure python database driver.

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ What's CyMySQL
 
 This package contains a python MySQL client library.
 
-It is a fork project from PyMySQL http://www.pymysql.org/ .
+It is a fork project from PyMySQL https://pymysql.readthedocs.io.
 
 PyMySQL is written by Yutaka Matsubara <yutaka.matsubara@gmail.com>
 as a pure python database driver.


### PR DESCRIPTION
pymysql.org domain seems to expired. edited readme to point to read docs link. 
we can even point to github page.