### PR TITLE
Add aio submodule to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     description='Python MySQL Driver using Cython',
     long_description=open('README.rst').read(),
     license="MIT",
-    packages=['cymysql', 'cymysql.constants', 'cymysql.tests'],
+    packages=['cymysql', 'cymysql.aio', 'cymysql.constants', 'cymysql.tests'],
     cmdclass=cmdclass,
     ext_modules=ext_modules,
 )


### PR DESCRIPTION
As aio is not added in packages list it is not added into the build which causes `pip install cymysql` to fail with following error:
```
Collecting cymysql
  Downloading cymysql-1.0.0.tar.gz (739 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 739.1/739.1 kB 29.3 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-25svd7wg/cymysql_fa6c70ceb6a14b99b5317d1b130b219e/setup.py", line 46, in <module>
          version_tuple = __import__('cymysql').VERSION
        File "/tmp/pip-install-25svd7wg/cymysql_fa6c70ceb6a14b99b5317d1b130b219e/cymysql/__init__.py", line 39, in <module>
          from cymysql import aio
      ImportError: cannot import name 'aio' from 'cymysql' (/tmp/pip-install-25svd7wg/cymysql_fa6c70ceb6a14b99b5317d1b130b219e/cymysql/__init__.py)
      [end of output]
``` 